### PR TITLE
Variable to fetch blocks by criteria

### DIFF
--- a/neo/variables/NeoVariable.php
+++ b/neo/variables/NeoVariable.php
@@ -47,4 +47,15 @@ class NeoVariable
 
 		return (bool) $criteria->first();
 	}
+    
+	/**
+	 * @param array|null $criteria
+	 *
+	 * @return ElementCriteriaModel
+	 */
+	public function blocks($criteria = null)
+	{
+        return craft()->elements->getCriteria(Neo_ElementType::NeoBlock, $criteria);
+	}
+        
 }


### PR DESCRIPTION
Usage:
`{% set sessions = craft.neo.blocks({section: 'events', relatedTo: person, 'role': 'speaker', 'order': 'eventStart DESC'}) %}`