### PR TITLE
Fix get keywords for only neo fields handles and not all field handles

### DIFF
--- a/neo/services/NeoService.php
+++ b/neo/services/NeoService.php
@@ -681,25 +681,24 @@ class NeoService extends BaseApplicationComponent
 		craft()->content->fieldColumnPrefix = $block->getFieldColumnPrefix();
 		craft()->content->fieldContext = $block->getFieldContext();
 
-        foreach ($block->getFieldLayout()->getFields() as $fieldLayoutField) //Only get keywords for the current block fields
-        {
-            $field = $fieldLayoutField->getField();
+		foreach ($block->getFieldLayout()->getFields() as $fieldLayoutField) //Only get keywords for the current block fields
+		{
+			$field = $fieldLayoutField->getField();
 
-            if ($field)
-            {
-                $fieldType = $field->getFieldType();
+			if ($field) {
+				$fieldType = $field->getFieldType();
 
-                if ($fieldType)
-                {
-                    $oldElement = $fieldType->element; //Fix for override if nested element save
-                    $fieldType->element = $block;
+				if ($fieldType) {
+					$oldElement = $fieldType->element; //Fix for override if nested element save
+					$fieldType->element = $block;
 
-                    $handle = $field->handle;
-                    $keywords[] = $fieldType->getSearchKeywords($block->getFieldValue($handle));
-                    $fieldType->element = $oldElement; //Fix for override if nested element save
-                }
-            }
-        }
+					$handle = $field->handle;
+					$keywords[] = $fieldType->getSearchKeywords($block->getFieldValue($handle));
+
+					$fieldType->element = $oldElement; //Fix for override if nested element save
+				}
+			}
+		}
 
 		craft()->content->contentTable = $contentTable;
 		craft()->content->fieldColumnPrefix = $fieldColumnPrefix;

--- a/neo/services/NeoService.php
+++ b/neo/services/NeoService.php
@@ -681,17 +681,25 @@ class NeoService extends BaseApplicationComponent
 		craft()->content->fieldColumnPrefix = $block->getFieldColumnPrefix();
 		craft()->content->fieldContext = $block->getFieldContext();
 
-		foreach(craft()->fields->getAllFields() as $field)
-		{
-			$fieldType = $field->getFieldType();
+        foreach ($block->getFieldLayout()->getFields() as $fieldLayoutField) //Only get keywords for the current block fields
+        {
+            $field = $fieldLayoutField->getField();
 
-			if($fieldType)
-			{
-				$fieldType->element = $block;
-				$handle = $field->handle;
-				$keywords[] = $fieldType->getSearchKeywords($block->getFieldValue($handle));
-			}
-		}
+            if ($field)
+            {
+                $fieldType = $field->getFieldType();
+
+                if ($fieldType)
+                {
+                    $oldElement = $fieldType->element; //Fix for override if nested element save
+                    $fieldType->element = $block;
+
+                    $handle = $field->handle;
+                    $keywords[] = $fieldType->getSearchKeywords($block->getFieldValue($handle));
+                    $fieldType->element = $oldElement; //Fix for override if nested element save
+                }
+            }
+        }
 
 		craft()->content->contentTable = $contentTable;
 		craft()->content->fieldColumnPrefix = $fieldColumnPrefix;


### PR DESCRIPTION
Iterating over all field handles and overwriting the element in the fieldType breaks other plugins that save other elements depending on the current save event. Instead only iterate over the current NeoBlock fields